### PR TITLE
fixed top-bar this way we can change the color without it looking bad.

### DIFF
--- a/lisk-dex-electron/src/App.css
+++ b/lisk-dex-electron/src/App.css
@@ -38,11 +38,15 @@ li {
 
 .top-bar {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   height: 50px;
-  width: 95%;
-  margin-left: auto;
+  width: auto;
+  padding: 0 10px;
+  background-color: #000;
+}
+
+.top-bar-title {
   margin-right: auto;
 }
 

--- a/lisk-dex-electron/src/App.jsx
+++ b/lisk-dex-electron/src/App.jsx
@@ -862,7 +862,7 @@ class App extends React.Component {
           {this.state.displaySigninModal && <SignInModal submitLoginDetails={this.submitLoginDetails} enabledAssets={this.state.activeAssets} close={this.closeSignInModal} walletGenerated={this.walletGenerated} assetAdapters={this.assetAdapters} />}
           {this.state.displayLeaveWarning && <LeaveWarning setDisplayLeaveWarning={this.setDisplayLeaveWarning} />}
           <div className="top-bar">
-            <div>
+            <div className="top-bar-title">
               <b style={{ fontSize: '21px' }}>{GC.getAppTitle()}</b>
               {' '}
               &nbsp;


### PR DESCRIPTION
The `top-bar` class was pretty flawed. When changing the `bg-color` on the original one it showed black bars on the side. `width` was 95% which shouldn't be the way to style a navbar. Made some changes and now its width is spread fully and I added padding on the right and left side. `align-items` is still centered.